### PR TITLE
Replace Xperience Hub text with logo in Dashboard sidebar

### DIFF
--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -104,7 +104,7 @@ const Dashboard = () => {
       {/* Sidebar */}
       <aside className="w-full md:w-64 bg-white border-r border-gray-100 p-6 flex flex-col shrink-0">
         <div className="mb-10 px-2">
-            <h2 className="text-xl font-black text-gray-900 tracking-tight uppercase italic">Xperience <span className="text-orange-500">Hub</span></h2>
+            <img src="/logo.svg" alt="Xperience Hub" className="h-10 w-auto" />
         </div>
 
         <nav className="space-y-2 flex-grow">


### PR DESCRIPTION
The text-based "Xperience Hub" branding in the dashboard sidebar has been replaced with the company's SVG logo for better visual consistency. 

Key changes:
- Modified `src/pages/Dashboard/index.tsx` to replace the `<h2>` brand element with an `<img>` tag.
- Used the `/logo.svg` path from the public directory.
- Adjusted sizing to `h-10 w-auto` to fit comfortably within the sidebar.
- Verified the change visually using a Playwright script.

---
*PR created automatically by Jules for task [1137279881085253996](https://jules.google.com/task/1137279881085253996) started by @govinda777*