### PR TITLE
Use correct typing for batch transactions

### DIFF
--- a/src/services/accountAbstraction.ts
+++ b/src/services/accountAbstraction.ts
@@ -200,19 +200,23 @@ class AccountAbstractionService {
     data: string,
     value: bigint = BigInt(0),
   ): Promise<string> {
-    if (!this.alchemyClient || !this.alchemyClient.account) {
+    const client = this.alchemyClient;
+    const account = this.alchemyClient?.account;
+
+    if (!client || !account) {
       throw new Error("Alchemy Provider or Account not initialized");
     }
 
     try {
-      const hash = await this.alchemyClient.sendTransaction({
+      const hash = await client.sendTransaction({
         to: target as `0x${string}`,
         data: data as `0x${string}`,
         value,
-      } as any); // Use type assertion to bypass type checking
+        account,
+      });
 
       // Wait for the transaction to be included in a block
-      const txHash = await this.alchemyClient.waitForUserOperationTransaction({
+      const txHash = await client.waitForUserOperationTransaction({
         hash,
       });
 
@@ -387,7 +391,10 @@ class AccountAbstractionService {
     datas: string[],
     values: bigint[] = [],
   ): Promise<string> {
-    if (!this.alchemyClient || !this.alchemyClient.account) {
+    const client = this.alchemyClient;
+    const account = this.alchemyClient?.account;
+
+    if (!client || !account) {
       throw new Error("Alchemy Provider or Account not initialized");
     }
 
@@ -405,14 +412,14 @@ class AccountAbstractionService {
         value: paddedValues[i],
       }));
 
-      // Fix: Use the correct typing for batch transactions
-      const hash = await this.alchemyClient.sendTransactions({
+      // Use the correct typing for batch transactions
+      const hash = await client.sendTransactions({
         requests,
-        account: this.alchemyClient.account,
+        account,
       });
 
       // Wait for the transaction to be included in a block
-      const txHash = await this.alchemyClient.waitForUserOperationTransaction({
+      const txHash = await client.waitForUserOperationTransaction({
         hash,
       });
 


### PR DESCRIPTION
Improved type safety in `src/services/accountAbstraction.ts` by removing `as any` bypasses and correctly typing Alchemy SDK transaction calls. This ensures that both single and batch transactions are properly validated by the TypeScript compiler.

---
*PR created automatically by Jules for task [14967820193751222838](https://jules.google.com/task/14967820193751222838) started by @govinda777*