### PR TITLE
build: update axios to resolve security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@walletconnect/ethereum-provider": "^2.23.9",
     "@walletconnect/universal-provider": "^2.23.9",
     "ai": "^6.0.141",
-    "axios": "1.14.0",
+    "axios": "1.15.2",
     "browserify-sign": "^4.2.3",
     "buffer": "^6.0.3",
     "crypto-js": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^6.0.141
         version: 6.0.141(zod@3.25.76)
       axios:
-        specifier: 1.14.0
-        version: 1.14.0
+        specifier: 1.15.2
+        version: 1.15.2
       browserify-sign:
         specifier: ^4.2.3
         version: 4.2.5
@@ -4579,8 +4579,8 @@ packages:
     peerDependencies:
       axios: 0.x || 1.x
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   babel-core@7.0.0-bridge.0:
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
@@ -10469,8 +10469,8 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
-      axios: 1.14.0
-      axios-retry: 4.5.0(axios@1.14.0)
+      axios: 1.15.2
+      axios-retry: 4.5.0(axios@1.15.2)
       jose: 6.2.2
       md5: 2.3.0
       uncrypto: 0.1.3
@@ -16701,7 +16701,7 @@ snapshots:
       '@ethersproject/wallet': 5.8.0
       '@ethersproject/web': 5.8.0
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
-      axios: 1.14.0
+      axios: 1.15.2
       sturdy-websocket: 0.2.1
       websocket: 1.0.35
     transitivePeerDependencies:
@@ -16876,12 +16876,12 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios-retry@4.5.0(axios@1.14.0):
+  axios-retry@4.5.0(axios@1.15.2):
     dependencies:
-      axios: 1.14.0
+      axios: 1.15.2
       is-retry-allowed: 2.2.0
 
-  axios@1.14.0:
+  axios@1.15.2:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5


### PR DESCRIPTION
Updated `axios` from 1.14.0 to 1.15.2 to resolve high and moderate severity vulnerabilities (CVE-2025-62718, Prototype Pollution, CRLF Injection, SSRF). Tested using test suites to ensure stability and compatibility.

---
*PR created automatically by Jules for task [935972005417759213](https://jules.google.com/task/935972005417759213) started by @govinda777*