### PR TITLE
Fix Prisma TS compilation and implicit 'any' parameter

### DIFF
--- a/api/_routes/xp/index.ts
+++ b/api/_routes/xp/index.ts
@@ -76,7 +76,7 @@ async function handler(req: AuthenticatedRequest, res: VercelResponse) {
       }
 
       // Execute transaction
-      const result = await prisma.$transaction(async (tx) => {
+      const result = await prisma.$transaction(async (tx: any) => {
         // 1. Update or create UserXp
         const userXp = await tx.userXp.upsert({
           where: { userId },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "precommit": "./pipeline.sh",
     "prepare": "husky install",
+    "postinstall": "prisma generate",
     "fast-install": "./scripts/fast-install.sh",
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
Fix Vercel TS compilation errors for prisma and explicitly typed parameter

- Added `"postinstall": "prisma generate"` to `package.json` to fix `Module '@prisma/client' has no exported member 'PrismaClient'` during deployment.
- Explicitly typed the `tx` parameter as `any` in `api/_routes/xp/index.ts` to solve the `error TS7006: Parameter 'tx' implicitly has an 'any' type`.

---
*PR created automatically by Jules for task [10858270408892703114](https://jules.google.com/task/10858270408892703114) started by @govinda777*