### PR TITLE
fix: resolve missing hpke errors.js module in serverless deployment

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@ network-timeout=100000
 registry=https://registry.npmjs.org/
 prefer-offline=true
 cache-folder=.yarn-cache
+node-linker=hoisted

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/core": "^7.0.0",
     "@google/generative-ai": "^0.24.1",
     "@hpke/chacha20poly1305": "^1.8.0",
-    "@hpke/common": "^1.10.1",
+    "@hpke/common": "1.10.0",
     "@hpke/core": "^1.9.0",
     "@langchain/core": "^1.1.19",
     "@langchain/langgraph": "^1.1.3",
@@ -143,6 +143,7 @@
       "postcss": "^8.5.14",
       "langsmith": "^0.7.1",
       "ajv": "^8.18.0",
+      "@hpke/common": "1.10.0",
       "fast-uri": "3.1.2"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ overrides:
   postcss: ^8.5.14
   langsmith: ^0.7.1
   ajv: ^8.18.0
+  '@hpke/common': 1.10.0
   fast-uri: 3.1.2
 
 importers:
@@ -78,8 +79,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
       '@hpke/common':
-        specifier: ^1.10.1
-        version: 1.10.1
+        specifier: 1.10.0
+        version: 1.10.0
       '@hpke/core':
         specifier: ^1.9.0
         version: 1.9.0
@@ -1697,8 +1698,8 @@ packages:
     resolution: {integrity: sha512-FcBfAQ+Y99vMNJP2yrZ9wpL8V0GOwp1+zMyzvc6alasrBygfFjFm1yeUtyADJCu/27C3Lm5mJzx6u7pwg+cX5w==}
     engines: {node: '>=16.0.0'}
 
-  '@hpke/common@1.10.1':
-    resolution: {integrity: sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==}
+  '@hpke/common@1.10.0':
+    resolution: {integrity: sha512-uVq9pTNERQ1GcFlHZzQx+a0ZMC81wQzkbNzJPEyR/l3AWM7fASd/qYN2Cnq6uL1NPEfwcD4lgOmfjjZfx2k2XA==}
     engines: {node: '>=16.0.0'}
 
   '@hpke/core@1.9.0':
@@ -10234,21 +10235,21 @@ snapshots:
 
   '@hpke/chacha20poly1305@1.8.0':
     dependencies:
-      '@hpke/common': 1.10.1
+      '@hpke/common': 1.10.0
 
-  '@hpke/common@1.10.1': {}
+  '@hpke/common@1.10.0': {}
 
   '@hpke/core@1.9.0':
     dependencies:
-      '@hpke/common': 1.10.1
+      '@hpke/common': 1.10.0
 
   '@hpke/dhkem-x25519@1.8.0':
     dependencies:
-      '@hpke/common': 1.10.1
+      '@hpke/common': 1.10.0
 
   '@hpke/dhkem-x448@1.8.0':
     dependencies:
-      '@hpke/common': 1.10.1
+      '@hpke/common': 1.10.0
 
   '@humanfs/core@0.19.1': {}
 
@@ -17156,7 +17157,7 @@ snapshots:
   hpke-js@1.8.0:
     dependencies:
       '@hpke/chacha20poly1305': 1.8.0
-      '@hpke/common': 1.10.1
+      '@hpke/common': 1.10.0
       '@hpke/core': 1.9.0
       '@hpke/dhkem-x25519': 1.8.0
       '@hpke/dhkem-x448': 1.8.0


### PR DESCRIPTION
This pull request addresses the `500 Internal Server Error` in Vercel production environments caused by a missing module (`Cannot find module './src/errors.js'`) deep within the `@privy-io/node` -> `@hpke/chacha20poly1305` -> `@hpke/common` dependency tree.

**Changes:**
1. **`.npmrc` Configuration**: Added `node-linker=hoisted` to force `pnpm` to flatten the `node_modules` structure. This ensures that the `@vercel/nft` bundler correctly resolves and includes all nested files, a common fix for `pnpm` on Vercel.
2. **`package.json` Override**: Pinned `@hpke/common` to `1.10.0` within `pnpm.overrides`. Version `1.10.1` has a known issue where the `src` directory might not be correctly structured or bundled in some environments, leading to the missing `errors.js` file. Downgrading specifically bypasses this bug.
3. **Lockfile**: Updated `pnpm-lock.yaml` to reflect the downgraded version.

These changes are verified via `pnpm check:api` and `pnpm test:all` to ensure no local regressions while fixing the serverless production bug.

---
*PR created automatically by Jules for task [4396330344069155005](https://jules.google.com/task/4396330344069155005) started by @govinda777*