### PR TITLE
Fix Vercel bundling for @hpke dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2376,7 +2376,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
+    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
   '@phosphor-icons/webcomponents@2.1.5':
     resolution: {integrity: sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==}

--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,8 @@
 
   "functions": {
     "api/index.ts": {
-      "maxDuration": 60
+      "maxDuration": 60,
+      "includeFiles": "node_modules/@hpke/**/*.js"
     }
   },
 


### PR DESCRIPTION
- Modifies `vercel.json` to explicitly configure `includeFiles` for `api/index.ts`.
- Targets all Javascript files in `node_modules/@hpke/` to resolve the `Cannot find module './src/errors.js'` 500 runtime error when the serverless function executes.

---
*PR created automatically by Jules for task [15413768647296047782](https://jules.google.com/task/15413768647296047782) started by @govinda777*