### PR TITLE
docs: add 5 new Blue Ocean market niche case studies

### DIFF
--- a/doc/blue-ocean/escritorio-advocacia.md
+++ b/doc/blue-ocean/escritorio-advocacia.md
@@ -1,0 +1,74 @@
+# Estudo de Caso Blue Ocean: Escritório de Advocacia
+
+## Da "Batalha Judicial Tradicional" para "Prevenção e Solução Extrajudicial Ágil"
+
+### 1. O Cenário Atual (Oceano Vermelho)
+
+O mercado tradicional de advocacia sofre com alta concorrência, morosidade e faturamento atrelado ao tempo:
+
+1. **Foco no Litígio Longo:** Escritórios que vivem de processos judiciais arrastados, onde o cliente não entende o juridiquês e se sente refém do tempo.
+2. **Cobrança Imprevisível:** Honorários complexos baseados em taxas iniciais somadas a um percentual imprevisível ao final de processos de anos.
+3. **Atendimento Frio e Reativo:** O advogado só é acionado quando o problema já explodiu, atuando como "bombeiro" e não como parceiro de negócios.
+
+### 2. A Estratégia do Oceano Azul: "Advocacia Preventiva e Extrajudicial"
+
+A estratégia propõe uma transição da advocacia de contencioso demorado para a atuação extrajudicial (acordos rápidos, mediação) e a consultoria preventiva focada na saúde e segurança financeira da empresa do cliente.
+
+**A Nova Proposta de Valor:**
+
+- **Foco:** Pequenas e médias empresas (ou clientes pessoas físicas) que buscam evitar o judiciário, reduzir riscos e resolver conflitos rapidamente, mesmo que isso custe mais no curto prazo.
+- **Ambiente:** Tecnológico e direto (Legal Design, contratos visuais, reuniões ágeis), eliminando a formalidade desnecessária e o juridiquês.
+- **Modelo de Negócio:** Receita recorrente (Fee Mensal) para consultoria preventiva ou cobrança por soluções rápidas e pacotes de acordos extrajudiciais.
+
+### 3. Strategy Canvas (Tela Estratégica)
+
+O gráfico compara o modelo do escritório contencioso com o novo modelo focado em prevenção e agilidade.
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Escritório Tradicional vs. Prevenção/Extrajudicial"
+    x-axis ["Uso de Juridiquês", "Tempo Esperando o Judiciário", "Foco em Litígio/Briga", "Contratos Visuais (Legal Design)", "Soluções Extrajudiciais Rápidas", "Consultoria Preventiva e Recorrente", "Transparência ao Cliente"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [9, 10, 9, 1, 2, 2, 3]
+    line [1, 2, 2, 9, 10, 10, 10]
+```
+
+**Legenda:**
+
+- **Linha 1:** Escritório Tradicional (Contencioso)
+- **Linha 2:** Prevenção e Extrajudicial (Blue Ocean)
+
+### 4. Framework das Quatro Ações (ERRC Grid)
+
+| Ação         | O que fazer                                                                                                                                                                                                                                               |
+| :----------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ELIMINAR** | **Juridiquês desnecessário:** Falar a língua do empreendedor ou do cliente final.<br>**Dependência total do Judiciário:** Deixar de vender a ilusão de que a "justiça estatal" é o único caminho.                                                         |
+| **REDUZIR**  | **Tempo de resposta:** Reduzir o tempo que o cliente fica "no escuro" sobre o andamento do caso.<br>**Processos judiciais longos:** Menos brigas desgastantes de 5 a 10 anos.                                                                             |
+| **AUMENTAR** | **Acordos e Mediações:** Focar massivamente na resolução amigável e rápida dos conflitos.<br>**Transparência:** Mostrar ao cliente exatamente onde ele está e os próximos passos de forma visual.                                                         |
+| **CRIAR**    | **Legal Design em Contratos:** Tornar os contratos agradáveis e fáceis de ler.<br>**Planos de Assinatura Preventiva:** Vender "tranquilidade mensal" onde o escritório audita a empresa para que ela não seja processada (Compliance Trabalhista/Fiscal). |
+
+### 5. Conclusão
+
+Sair da briga por "quem cobra mais barato no percentual de êxito" no fim de um processo demorado. Ao focar em prevenir riscos (compliance, estruturação de contratos inteligentes) e resolver conflitos rápido (extrajudicial), o escritório atrai clientes dispostos a pagar por tranquilidade, previsibilidade e agilidade, garantindo um fluxo de caixa constante via contratos recorrentes ou honorários pagos pelo sucesso rápido em acordos.
+
+### 6. Veja Também (Outros Estudos de Caso)
+
+- [Turismo de Compras Têxtil](./turismo-compras-textil.md)
+- [Pousadas e Campings](./pousadas-campings.md)
+- [Academia de Escalada](./academia-escalada.md)
+- [Personal Trainer](./personal-trainer.md)
+- [Consultoria Empreendedora](./consultoria-empreendedora.md)
+- [Agência de Marketing](./agencia-marketing.md)
+- [Barbearia](./barbearia.md)
+- [Clínica de Estética](./clinica-estetica.md)
+- [Pet Shop](./pet-shop.md)
+- [Cafeteria](./cafeteria.md)
+- [Oficina Mecânica](./oficina-mecanica.md)
+- [Escola de Idiomas](./escola-idiomas.md)
+- [Startup B2B SaaS](./startup-saas.md)
+- [Food Truck e Comida de Rua](./food-truck.md)
+- [Delivery de Comida Saudável](./delivery-saudavel.md)
+- [Loja de Roupas](./loja-roupas.md)
+- [Estúdio de Yoga](./estudio-yoga.md)
+- [Coworking de Nicho](./coworking.md)
+- [Imobiliária Consultiva](./imobiliaria.md)

--- a/doc/blue-ocean/fotografia.md
+++ b/doc/blue-ocean/fotografia.md
@@ -1,0 +1,76 @@
+# Estudo de Caso Blue Ocean: Fotografia
+
+## Do "Fotógrafo de Casamento" para o "Estrategista de Imagem Profissional"
+
+### 1. O Cenário Atual (Oceano Vermelho)
+
+O mercado da fotografia tradicional está saturado e enfrenta desafios devido à popularização dos smartphones:
+
+1. **Guerra de Preços em Eventos:** Alta concorrência no nicho de casamentos e festas infantis, com clientes pechinchando pacotes e exigindo a entrega de todas as fotos.
+2. **Equipamento como Diferencial:** Profissionais tentando se destacar apenas dizendo que usam câmeras caras, o que não reflete valor claro para o cliente leigo.
+3. **Fotografia como "Gasto":** O cliente final enxerga o ensaio apenas como uma lembrança ou luxo, dificultando a cobrança de tickets muito altos (exceto na altíssima renda).
+
+### 2. A Estratégia do Oceano Azul: "Estrategista de Imagem Profissional"
+
+A estratégia propõe migrar do nicho de "eventos e lembranças" para a fotografia comercial focada em construir a autoridade e alavancar os negócios de outros profissionais (Personal Branding).
+
+**A Nova Proposta de Valor:**
+
+- **Foco:** Empreendedores, médicos, advogados, corretores e consultores que precisam transmitir autoridade nas redes sociais para venderem mais caros os seus próprios serviços.
+- **Ambiente:** Estúdio corporativo moderno, locações estratégicas (clínicas, escritórios) com curadoria de roupas e postura.
+- **Modelo de Negócio:** A foto deixa de ser "lembrança" para ser "ferramenta de vendas". O serviço engloba direção de imagem, paleta de cores e banco de imagens anual para redes sociais.
+
+### 3. Strategy Canvas (Tela Estratégica)
+
+Comparativo entre o fotógrafo de eventos e o estrategista de imagem focado em negócios.
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Fotógrafo de Eventos vs. Estrategista de Imagem"
+    x-axis ["Dependência de Eventos (Fim de Semana)", "Concorrência por Preço", "Entrega de 'Lembranças'", "Foco em Posicionamento/Vendas", "Curadoria de Imagem (Roupa/Postura)", "Venda de Retrato como Investimento (B2B)", "Contratos Recorrentes (Banco de Imagens)"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [10, 9, 9, 1, 2, 2, 1]
+    line [1, 2, 2, 10, 9, 10, 8]
+```
+
+**Legenda:**
+
+- **Linha 1:** Fotógrafo de Eventos Tradicional
+- **Linha 2:** Estrategista de Imagem / Retrato Corporativo (Blue Ocean)
+
+### 4. Framework das Quatro Ações (ERRC Grid)
+
+| Ação         | O que fazer                                                                                                                                                                                                                                        |
+| :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ELIMINAR** | **O trabalho aos finais de semana:** Focar em atender profissionais no horário comercial (segunda a sexta).<br>**Guerra de orçamentos de casamentos:** Sair das plataformas genéricas de eventos.                                                  |
+| **REDUZIR**  | **Foco extremo no equipamento:** Parar de vender "megapixels" e começar a vender a "mensagem que a foto transmite".<br>**Tempo de edição massiva:** Ensaios corporativos exigem menos fotos entregues, porém de maior impacto, do que uma festa. |
+| **AUMENTAR** | **Direção de Pessoas:** Focar em deixar clientes que não são modelos relaxados e com postura de autoridade na frente da câmera.<br>**Ticket Médio:** Aumentar o preço, já que o cliente B2B recupera esse investimento em vendas próprias.         |
+| **CRIAR**    | **Consultoria de Posicionamento:** Ajudar o cliente a definir quais roupas e expressões usar para atrair o público alvo correto.<br>**Pacotes Recorrentes:** Criar planos trimestrais ou anuais de renovação de banco de imagens para Instagram.   |
+
+### 5. Conclusão
+
+Sair da "fotografia como custo de evento" para a "fotografia como investimento em marketing pessoal". Ao ajudar médicos ou advogados a parecerem mais caros e confiáveis, o fotógrafo justifica honorários muito mais altos. Além disso, melhora a própria qualidade de vida, trocando as exaustivas madrugadas de sábado por ensaios estratégicos nas terças à tarde, abrindo a possibilidade de assinaturas de conteúdo visual recorrente.
+
+### 6. Veja Também (Outros Estudos de Caso)
+
+- [Odontologia](./odontologia.md)
+- [Escritório de Advocacia](./escritorio-advocacia.md)
+- [Turismo de Compras Têxtil](./turismo-compras-textil.md)
+- [Pousadas e Campings](./pousadas-campings.md)
+- [Academia de Escalada](./academia-escalada.md)
+- [Personal Trainer](./personal-trainer.md)
+- [Consultoria Empreendedora](./consultoria-empreendedora.md)
+- [Agência de Marketing](./agencia-marketing.md)
+- [Barbearia](./barbearia.md)
+- [Clínica de Estética](./clinica-estetica.md)
+- [Pet Shop](./pet-shop.md)
+- [Cafeteria](./cafeteria.md)
+- [Oficina Mecânica](./oficina-mecanica.md)
+- [Escola de Idiomas](./escola-idiomas.md)
+- [Startup B2B SaaS](./startup-saas.md)
+- [Food Truck e Comida de Rua](./food-truck.md)
+- [Delivery de Comida Saudável](./delivery-saudavel.md)
+- [Loja de Roupas](./loja-roupas.md)
+- [Estúdio de Yoga](./estudio-yoga.md)
+- [Coworking de Nicho](./coworking.md)
+- [Imobiliária Consultiva](./imobiliaria.md)

--- a/doc/blue-ocean/lavanderia.md
+++ b/doc/blue-ocean/lavanderia.md
@@ -1,0 +1,77 @@
+# Estudo de Caso Blue Ocean: Lavanderia
+
+## Do "Comércio Local de Roupas Sujas" para "Serviço de Gestão de Guarda-Roupa"
+
+### 1. O Cenário Atual (Oceano Vermelho)
+
+O mercado de lavanderias de bairro e franquias tradicionais sofre com margens apertadas e dependência do fluxo de rua:
+
+1. **Serviço Reativo:** O cliente só leva as roupas quando a situação está crítica ou para lavar itens muito grandes (edredons), o que gera um fluxo de caixa irregular.
+2. **Competição por Preço (Peça por Peça):** O foco é vender lavagem e passadoria por peça, entrando em guerra de preços com outras lavanderias da região ou com as máquinas domésticas.
+3. **Logística Ineficiente:** O cliente precisa ir fisicamente ao local, o que afasta o público jovem e ocupado que preza pela conveniência extrema.
+
+### 2. A Estratégia do Oceano Azul: "Gestão de Guarda-Roupa e Assinatura"
+
+A estratégia transforma a lavanderia de um "ponto comercial físico para lavagem avulsa" em um serviço tecnológico de gestão do vestuário (Laundry as a Service - LaaS), voltado para assinatura.
+
+**A Nova Proposta de Valor:**
+
+- **Foco:** Profissionais solteiros, executivos e jovens casais de classe média/alta que não têm tempo (ou não querem) perder horas de final de semana lavando e passando roupas.
+- **Ambiente:** Aplicativo focado na experiência do usuário, "lockers" (armários inteligentes) em condomínios e logística invisível.
+- **Modelo de Negócio:** Planos mensais de assinatura (Ex: Cesto Semanal), com coleta e entrega em domicílio, garantindo previsibilidade de faturamento.
+
+### 3. Strategy Canvas (Tela Estratégica)
+
+Comparativo entre a lavanderia tradicional com cobrança por peça e o serviço por assinatura digital.
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Lavanderia de Bairro vs. Gestão de Guarda-Roupa (LaaS)"
+    x-axis ["Dependência de Ponto Físico/Balcão", "Cobrança por Peça Avulsa", "Responsabilidade do Cliente ir até o Local", "Conveniência e Logística (Delivery)", "Modelo de Assinatura Recorrente", "Uso de Lockers em Condomínios", "Gestão Digital via App"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [9, 10, 10, 2, 1, 1, 1]
+    line [2, 1, 1, 10, 10, 9, 10]
+```
+
+**Legenda:**
+
+- **Linha 1:** Lavanderia Tradicional
+- **Linha 2:** Gestão de Guarda-Roupa / LaaS (Blue Ocean)
+
+### 4. Framework das Quatro Ações (ERRC Grid)
+
+| Ação         | O que fazer                                                                                                                                                                                                          |
+| :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ELIMINAR** | **O Balcão de Atendimento Físico:** Eliminar a dependência de um ponto comercial caro na rua principal; a operação pode ir para um galpão mais barato.<br>**Preços complexos:** Tabela com dezenas de preços por peça de roupa. |
+| **REDUZIR**  | **Atrito para o Cliente:** Reduzir o esforço do cliente para ter a roupa limpa.<br>**Irregularidade Financeira:** Diminuir a sazonalidade e imprevisibilidade da receita.                                            |
+| **AUMENTAR** | **Conveniência Absoluta:** O "problema da roupa suja" deve desaparecer da vida do cliente.<br>**Previsibilidade (MRR):** Focar em contratos mensais recorrentes para gerar previsibilidade no fluxo de caixa.        |
+| **CRIAR**    | **Planos de Assinatura:** Cestas/Bolsas com limite de peso/peças mensais.<br>**Parcerias B2B:** Instalação de armários inteligentes (lockers) em grandes condomínios residenciais e empresariais.                    |
+
+### 5. Conclusão
+
+Vender "tempo" em vez de vender "lavagem de roupas". O modelo por assinatura com delivery automatizado ou lockers retira a fricção da transação. A lavanderia otimiza sua operação saindo de pontos comerciais caros para galpões logísticos focados em produtividade, enquanto o cliente paga uma mensalidade previsível para se livrar de uma das tarefas domésticas mais odiadas.
+
+### 6. Veja Também (Outros Estudos de Caso)
+
+- [Fotografia](./fotografia.md)
+- [Odontologia](./odontologia.md)
+- [Escritório de Advocacia](./escritorio-advocacia.md)
+- [Turismo de Compras Têxtil](./turismo-compras-textil.md)
+- [Pousadas e Campings](./pousadas-campings.md)
+- [Academia de Escalada](./academia-escalada.md)
+- [Personal Trainer](./personal-trainer.md)
+- [Consultoria Empreendedora](./consultoria-empreendedora.md)
+- [Agência de Marketing](./agencia-marketing.md)
+- [Barbearia](./barbearia.md)
+- [Clínica de Estética](./clinica-estetica.md)
+- [Pet Shop](./pet-shop.md)
+- [Cafeteria](./cafeteria.md)
+- [Oficina Mecânica](./oficina-mecanica.md)
+- [Escola de Idiomas](./escola-idiomas.md)
+- [Startup B2B SaaS](./startup-saas.md)
+- [Food Truck e Comida de Rua](./food-truck.md)
+- [Delivery de Comida Saudável](./delivery-saudavel.md)
+- [Loja de Roupas](./loja-roupas.md)
+- [Estúdio de Yoga](./estudio-yoga.md)
+- [Coworking de Nicho](./coworking.md)
+- [Imobiliária Consultiva](./imobiliaria.md)

--- a/doc/blue-ocean/mercado-bairro.md
+++ b/doc/blue-ocean/mercado-bairro.md
@@ -1,0 +1,78 @@
+# Estudo de Caso Blue Ocean: Mercado de Bairro
+
+## Do "Minimercado de Emergência" para o "Centro de Experiência Gastronômica Local"
+
+### 1. O Cenário Atual (Oceano Vermelho)
+
+Os pequenos mercados de bairro (mercearias/minimercados) enfrentam uma pressão dupla e impiedosa:
+
+1. **Guerra de Preços Injusta:** É impossível competir em preço de produtos industrializados básicos (arroz, feijão, sabão em pó) com os grandes hipermercados e atacarejos.
+2. **Posicionamento de "Emergência":** O cliente só vai ao mercado de bairro quando "esqueceu" alguma coisa no atacarejo, o que limita o ticket médio a compras pequenas de última hora.
+3. **Ambiente Sem Atrativos:** Lojas espremidas, mal iluminadas, com mix de produtos genéricos, sem proporcionar nenhuma experiência agradável de compra.
+
+### 2. A Estratégia do Oceano Azul: "Centro de Experiência Gastronômica Local"
+
+A estratégia propõe tirar o pequeno mercado da categoria de "abastecimento de commodities por necessidade" e movê-lo para o nicho de "compra rápida premium, curadoria de produtos e consumo imediato".
+
+**A Nova Proposta de Valor:**
+
+- **Foco:** Moradores locais que buscam produtos frescos, artesanais, pães recém-assados, vinhos, cortes de carne premium e produtos para um jantar especial sem precisarem pegar o carro para ir ao hipermercado.
+- **Ambiente:** Layout limpo (conceito empório/boutique), iluminação quente, padaria central atraente, seção de hortifrúti fresco e impecável.
+- **Modelo de Negócio:** Maior margem de lucro através de produtos de valor agregado (padaria própria, rotisseria, adega, marcas artesanais locais) e menor foco na guerra do arroz com feijão.
+
+### 3. Strategy Canvas (Tela Estratégica)
+
+Comparativo entre o minimercado tradicional (focado em marcas de massa) e o mercado de experiência local.
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Mercado de Bairro Tradicional vs. Empório/Experiência Local"
+    x-axis ["Competição por Preço (Atacarejo)", "Mix Focado em Produtos Básicos", "Aspecto de Loja de 'Emergência'", "Curadoria de Produtos Locais/Artesanais", "Força da Padaria/Rotisseria Própria", "Foco em Refeições Prontas e Bebidas Premium", "Experiência de Loja (Iluminação/Layout)"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [9, 10, 9, 1, 3, 2, 2]
+    line [1, 3, 1, 10, 10, 9, 9]
+```
+
+**Legenda:**
+
+- **Linha 1:** Mercado de Bairro Tradicional
+- **Linha 2:** Centro de Experiência / Empório Local (Blue Ocean)
+
+### 4. Framework das Quatro Ações (ERRC Grid)
+
+| Ação         | O que fazer                                                                                                                                                                                                                                              |
+| :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ELIMINAR** | **A tentativa de competir em preço:** Parar de queimar margem tentando vender produtos básicos de limpeza mais barato que o atacarejo do bairro vizinho.                                                                                                 |
+| **REDUZIR**  | **Espaço de gôndola para grandes marcas comoditizadas:** Diminuir a variedade absurda de sabonetes e focar em abrir espaço para produtos de maior margem.<br>**Estoque estagnado:** Reduzir produtos de baixíssimo giro.                                 |
+| **AUMENTAR** | **O papel do Hortifrúti e Padaria:** Esses devem ser a "âncora" da loja, impecáveis, frescos e muito bem expostos.<br>**Produtos de impulso e consumo imediato:** Bebidas geladas premium, lanches frescos, refeições prontas (grab and go).           |
+| **CRIAR**    | **Setor de Curadoria (Empório):** Vinhos selecionados de bom custo-benefício, queijos artesanais, carnes nobres.<br>**Parcerias Locais:** Vender o pão de fermentação natural daquele vizinho, a cerveja artesanal da região, gerando senso de comunidade. |
+
+### 5. Conclusão
+
+Sair da rota de colisão com os hipermercados. O cliente vai ao atacarejo no final de semana para fazer a compra "pesada", mas quer o empório do bairro para comprar o pão quente da manhã, o vinho e a carne nobre para a sexta-feira à noite, e o queijo artesanal. Essa mudança aumenta drasticamente a margem de lucro e atrai um público disposto a pagar pela conveniência premium, transformando a "loja de emergência" em um ponto agradável de compras locais e descobertas gastronômicas.
+
+### 6. Veja Também (Outros Estudos de Caso)
+
+- [Lavanderia](./lavanderia.md)
+- [Fotografia](./fotografia.md)
+- [Odontologia](./odontologia.md)
+- [Escritório de Advocacia](./escritorio-advocacia.md)
+- [Turismo de Compras Têxtil](./turismo-compras-textil.md)
+- [Pousadas e Campings](./pousadas-campings.md)
+- [Academia de Escalada](./academia-escalada.md)
+- [Personal Trainer](./personal-trainer.md)
+- [Consultoria Empreendedora](./consultoria-empreendedora.md)
+- [Agência de Marketing](./agencia-marketing.md)
+- [Barbearia](./barbearia.md)
+- [Clínica de Estética](./clinica-estetica.md)
+- [Pet Shop](./pet-shop.md)
+- [Cafeteria](./cafeteria.md)
+- [Oficina Mecânica](./oficina-mecanica.md)
+- [Escola de Idiomas](./escola-idiomas.md)
+- [Startup B2B SaaS](./startup-saas.md)
+- [Food Truck e Comida de Rua](./food-truck.md)
+- [Delivery de Comida Saudável](./delivery-saudavel.md)
+- [Loja de Roupas](./loja-roupas.md)
+- [Estúdio de Yoga](./estudio-yoga.md)
+- [Coworking de Nicho](./coworking.md)
+- [Imobiliária Consultiva](./imobiliaria.md)

--- a/doc/blue-ocean/odontologia.md
+++ b/doc/blue-ocean/odontologia.md
@@ -1,0 +1,75 @@
+# Estudo de Caso Blue Ocean: Odontologia
+
+## Da "Odontologia de Dor e Curativa" para a "Clínica de Prevenção e Estética Premium"
+
+### 1. O Cenário Atual (Oceano Vermelho)
+
+O mercado odontológico é focado amplamente em combater problemas bucais já estabelecidos, muitas vezes operando em uma guerra de preços através de convênios:
+
+1. **Atendimento Focado na Dor/Problema:** O paciente só procura o dentista quando sente dor (cáries, canal, extração). O foco é curativo.
+2. **Dependência de Convênios:** Muitos profissionais são reféns de planos odontológicos que pagam valores irrisórios por procedimento, forçando-os a atender em alto volume para faturar.
+3. **Ambiente Clínico Estéril:** Clínicas com o clássico "cheiro de dentista", barulho de motor intimidador e sala de espera fria e ansiosa.
+
+### 2. A Estratégia do Oceano Azul: "Prevenção e Estética Premium"
+
+A estratégia desloca o consultório odontológico de um "local de sofrimento para tratar dor" para um ambiente de "spa odontológico" focado em manutenção preventiva contínua e aprimoramento da auto-estima.
+
+**A Nova Proposta de Valor:**
+
+- **Foco:** Pacientes que valorizam o sorriso como parte fundamental da estética e saúde, preferindo pagar mais para não sentir dor no futuro e para terem dentes perfeitos.
+- **Ambiente:** Spa Odontológico. Design sofisticado, aromaterapia, ausência de barulhos irritantes, atendimento acolhedor.
+- **Modelo de Negócio:** Descredenciamento de convênios. Foco em planos anuais de profilaxia/prevenção e procedimentos de alto valor agregado (lentes de contato, alinhadores invisíveis, harmonização facial).
+
+### 3. Strategy Canvas (Tela Estratégica)
+
+Comparativo entre a clínica convencional focada em convênios e a clínica estética preventiva premium.
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Clínica Tradicional vs. Prevenção e Estética Premium"
+    x-axis ["Dependência de Convênios", "Volume de Pacientes (Alta Rotatividade)", "Ambiente Estéril/Intimidador", "Foco em Estética e Prevenção", "Atendimento Tipo Spa (Conforto)", "Venda de Planos Anuais de Prevenção", "Preço/Ticket Médio"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [9, 9, 8, 3, 2, 1, 3]
+    line [1, 3, 1, 10, 10, 9, 9]
+```
+
+**Legenda:**
+
+- **Linha 1:** Clínica Odontológica Tradicional
+- **Linha 2:** Clínica de Prevenção e Estética (Blue Ocean)
+
+### 4. Framework das Quatro Ações (ERRC Grid)
+
+| Ação         | O que fazer                                                                                                                                                                                                                                   |
+| :----------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ELIMINAR** | **Atendimento por Convênios:** Sair do jogo de volume de baixo custo que desgasta o profissional.<br>**O "Cheiro e Barulho de Dentista":** Eliminar estímulos que causam ansiedade e medo nos pacientes.                                      |
+| **REDUZIR**  | **Tempo na Sala de Espera:** Organizar a agenda para atendimento pontual (sem a superlotação gerada por convênios).<br>**Foco no Curativo:** Reduzir a dependência financeira de tratar problemas complexos e dolorosos (canal, extrações).   |
+| **AUMENTAR** | **Experiência do Paciente (Conforto):** Oferecer fones com cancelamento de ruído, óculos de VR, massagem, aromaterapia.<br>**Ticket Médio:** Cobrar valores premium justificados pela experiência luxuosa e resultados estéticos superiores.  |
+| **CRIAR**    | **Planos Anuais de Prevenção (Recorrência):** Clubes de assinatura onde o paciente paga mensalidade para ir x vezes ao ano fazer limpeza e acompanhamento.<br>**Consultoria Estética Integrada:** Harmonização facial aliada à odontologia. |
+
+### 5. Conclusão
+
+Sair da "esteira de produção" imposta pelos planos odontológicos. Focar no nicho premium que procura experiência, conforto, beleza e prevenção. A clínica ganha recorrência financeira através dos clubes de prevenção, e lucra alto com as intervenções estéticas (alinhadores e lentes de contato dental), enquanto o paciente deixa de ter medo de ir ao dentista.
+
+### 6. Veja Também (Outros Estudos de Caso)
+
+- [Escritório de Advocacia](./escritorio-advocacia.md)
+- [Turismo de Compras Têxtil](./turismo-compras-textil.md)
+- [Pousadas e Campings](./pousadas-campings.md)
+- [Academia de Escalada](./academia-escalada.md)
+- [Personal Trainer](./personal-trainer.md)
+- [Consultoria Empreendedora](./consultoria-empreendedora.md)
+- [Agência de Marketing](./agencia-marketing.md)
+- [Barbearia](./barbearia.md)
+- [Clínica de Estética](./clinica-estetica.md)
+- [Pet Shop](./pet-shop.md)
+- [Cafeteria](./cafeteria.md)
+- [Oficina Mecânica](./oficina-mecanica.md)
+- [Escola de Idiomas](./escola-idiomas.md)
+- [Startup B2B SaaS](./startup-saas.md)
+- [Food Truck e Comida de Rua](./food-truck.md)
+- [Delivery de Comida Saudável](./delivery-saudavel.md)
+- [Loja de Roupas](./loja-roupas.md)
+- [Estúdio de Yoga](./estudio-yoga.md)
+- [Coworking de Nicho](./coworking.md)
+- [Imobiliária Consultiva](./imobiliaria.md)


### PR DESCRIPTION
This PR expands the Blue Ocean strategy portfolio by adding 5 new case studies to the `doc/blue-ocean` directory. These case studies follow the established objective, direct tone and formatting rules (including Mermaid Strategy Canvases without inline legends, ERRC grids, and cross-linking) to build a robust portfolio of templates.

### Changes
*   Added `escritorio-advocacia.md` (Law Firm)
*   Added `odontologia.md` (Dentistry)
*   Added `fotografia.md` (Photography)
*   Added `lavanderia.md` (Laundry Services)
*   Added `mercado-bairro.md` (Neighborhood Grocery)

---
*PR created automatically by Jules for task [10356630392686666742](https://jules.google.com/task/10356630392686666742) started by @govinda777*