### PR TITLE
Add Blue Ocean Strategy case study portfolio

### DIFF
--- a/doc/blue-ocean/academia-de-escalada.md
+++ b/doc/blue-ocean/academia-de-escalada.md
@@ -1,0 +1,43 @@
+# Estudo de Caso: Academia de Escalada
+
+## Cenários
+
+**Oceano Vermelho:**
+- Competição direta com academias tradicionais (musculação, crossfit).
+- Foco em mensalidades baixas.
+- Ambiente voltado exclusivamente para atletas e escaladores experientes.
+- Equipamentos e vias de alta dificuldade técnica intimidantes.
+- Alta rotatividade (churn) de iniciantes.
+
+**Oceano Azul:**
+- Foco em comunidade, bem-estar mental e superação lúdica (gamificação).
+- Ambiente acolhedor para iniciantes, famílias e crianças.
+- Espaço híbrido: integração com café, coworking e espaços de convivência.
+- Aulas de introdução focadas em superação de medos (alturas, confiança).
+- Venda de lifestyle, não apenas acesso às paredes.
+
+## Matriz ERRC
+
+- **Eliminar:** A intimidação do ambiente hipercompetitivo, foco exclusivo na performance física.
+- **Reduzir:** Barreiras de entrada técnica, complexidade inicial de equipamentos, planos anuais rígidos.
+- **Elevar:** Senso de comunidade, gamificação do progresso (rotas iniciantes claras), integração social.
+- **Criar:** Ambientes híbridos (café/coworking), programas de mentoria para novatos, eventos sociais de integração.
+
+## Strategy Canvas
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Academia de Escalada"
+    x-axis ["Preço Base", "Foco em Performance", "Equip. Complexo", "Acolhimento Iniciante", "Ambiente Comunitário", "Café/Coworking"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [4, 9, 8, 2, 4, 1]
+    line [7, 3, 2, 9, 9, 8]
+```
+*(Nota: Linha 1 = Oceano Vermelho; Linha 2 = Oceano Azul)*
+
+## Veja Também
+
+- [Turismo de Compras Têxtil](./turismo-compras-textil.md)
+- [Pousadas e Campings](./pousadas-e-campings.md)
+- [Personal Trainer](./personal-trainer.md)
+- [Consultoria Empreendedora](./consultoria-empreendedora.md)

--- a/doc/blue-ocean/consultoria-empreendedora.md
+++ b/doc/blue-ocean/consultoria-empreendedora.md
@@ -1,0 +1,43 @@
+# Estudo de Caso: Consultoria Empreendedora
+
+## Cenários
+
+**Oceano Vermelho:**
+- Relatórios densos e teóricos ("lero lero" corporativo).
+- Venda de horas de consultoria genérica de gestão.
+- Foco em empresas grandes e corporações tradicionais.
+- Entregáveis focados no "o que fazer" e não no "como fazer".
+- Baixa retenção, projetos isolados com alto custo de aquisição.
+
+**Oceano Azul:**
+- Foco em experiências enxutas e unit economics aplicados.
+- Mentorias práticas com acompanhamento de implementação ("mão na massa").
+- Nicho: Startups early-stage, solopreneurs e pequenas empresas em transição digital.
+- Frameworks visuais rápidos, checklists acionáveis e suporte diário via canais ágeis (ex: WhatsApp, Slack).
+- Modelos de assinatura e "Consultoria as a Service" (CaaS).
+
+## Matriz ERRC
+
+- **Eliminar:** Relatórios extensos sem aplicação prática, reuniões longas e teóricas.
+- **Reduzir:** Preço inicial elevado, jargões complexos ("lero lero"), foco exclusivo em teoria.
+- **Elevar:** Velocidade de implementação, objetividade extrema, acompanhamento contínuo.
+- **Criar:** Produtos produtizados, checklists acionáveis, comunidade de empreendedores, assinaturas recorrentes.
+
+## Strategy Canvas
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Consultoria Empreendedora"
+    x-axis ["Preço do Projeto", "Teoria e Relatórios", "Foco em Corp.", "Prática (Mão na Massa)", "Agilidade", "Comunidade/Assinatura"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [8, 9, 8, 3, 2, 1]
+    line [4, 1, 1, 9, 9, 8]
+```
+*(Nota: Linha 1 = Oceano Vermelho; Linha 2 = Oceano Azul)*
+
+## Veja Também
+
+- [Turismo de Compras Têxtil](./turismo-compras-textil.md)
+- [Pousadas e Campings](./pousadas-e-campings.md)
+- [Academia de Escalada](./academia-de-escalada.md)
+- [Personal Trainer](./personal-trainer.md)

--- a/doc/blue-ocean/personal-trainer.md
+++ b/doc/blue-ocean/personal-trainer.md
@@ -1,0 +1,43 @@
+# Estudo de Caso: Personal Trainer
+
+## Cenários
+
+**Oceano Vermelho:**
+- Venda de horas e treinos avulsos ("hora/aula").
+- Foco exclusivo em estética (emagrecimento, hipertrofia).
+- Disputa de preços no salão de musculação.
+- Rotina exaustiva para o profissional (baixa escalabilidade).
+- Atendimento focado apenas no tempo presencial da sessão.
+
+**Oceano Azul:**
+- Venda de programas de transformação e mentoria de estilo de vida.
+- Foco em nichos específicos (ex: reabilitação postural para executivos, preparo para grávidas, atletas de fim de semana).
+- Pacotes híbridos (presencial + consultoria online).
+- Acompanhamento 360º: sono, gestão de estresse, nutrição básica, rotina diária.
+- Alta percepção de valor (premium), com receita recorrente e menos dependência de horas.
+
+## Matriz ERRC
+
+- **Eliminar:** Venda de hora/aula isolada, concorrência por preço no salão.
+- **Reduzir:** Foco puramente em hipertrofia genérica, dependência da presença física.
+- **Elevar:** Especialização de nicho, acompanhamento diário digital, métricas de bem-estar global.
+- **Criar:** Programas de transformação (com começo, meio e fim), mentoria de hábitos, comunidade online de alunos.
+
+## Strategy Canvas
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Personal Trainer"
+    x-axis ["Preço/Hora", "Foco em Hipertrofia", "Presença Física", "Especialização/Nicho", "Acompanhamento 360", "Prog. Transformação"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [3, 9, 9, 2, 1, 1]
+    line [8, 3, 4, 9, 8, 9]
+```
+*(Nota: Linha 1 = Oceano Vermelho; Linha 2 = Oceano Azul)*
+
+## Veja Também
+
+- [Turismo de Compras Têxtil](./turismo-compras-textil.md)
+- [Pousadas e Campings](./pousadas-e-campings.md)
+- [Academia de Escalada](./academia-de-escalada.md)
+- [Consultoria Empreendedora](./consultoria-empreendedora.md)

--- a/doc/blue-ocean/pousadas-e-campings.md
+++ b/doc/blue-ocean/pousadas-e-campings.md
@@ -1,0 +1,43 @@
+# Estudo de Caso: Pousadas e Campings
+
+## Cenários
+
+**Oceano Vermelho:**
+- Batalha por preços nas plataformas de reserva (Booking, Airbnb).
+- Foco em infraestrutura básica: cama, banheiro, café da manhã padrão.
+- Sazonalidade extrema, alta ociosidade na baixa temporada.
+- Concorrência predatória regional.
+- Marketing focado em descontos e "pernoite".
+
+**Oceano Azul:**
+- Foco em "Retiros de Desconexão" (Digital Detox) e turismo de experiência.
+- Integração profunda com a natureza, design sustentável.
+- Experiências imersivas: oficinas gastronômicas, trilhas guiadas com propósito, yoga.
+- Público-alvo: Trabalhadores remotos estressados, casais buscando reconexão e ecoturistas premium.
+- Pacotes all-inclusive focados em bem-estar holístico.
+
+## Matriz ERRC
+
+- **Eliminar:** Check-in burocrático, dependência de OTAs (Agências de Turismo Online), distrações urbanas (TVs nos quartos).
+- **Reduzir:** Estruturas de concreto, custos de marketing genérico, ociosidade de baixa temporada.
+- **Elevar:** Imersão na natureza, personalização do atendimento, práticas sustentáveis (ESG).
+- **Criar:** Espaços de "Glamping" (camping com glamour), pacotes de vivência, espaços híbridos para nômades digitais.
+
+## Strategy Canvas
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Pousadas e Campings"
+    x-axis ["Preço", "TV e Tecnologia", "Disponibilidade em OTAs", "Contato c/ Natureza", "Sustentabilidade", "Bem-estar/Experiências"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [5, 8, 9, 4, 3, 2]
+    line [7, 1, 2, 9, 9, 9]
+```
+*(Nota: Linha 1 = Oceano Vermelho; Linha 2 = Oceano Azul)*
+
+## Veja Também
+
+- [Turismo de Compras Têxtil](./turismo-compras-textil.md)
+- [Academia de Escalada](./academia-de-escalada.md)
+- [Personal Trainer](./personal-trainer.md)
+- [Consultoria Empreendedora](./consultoria-empreendedora.md)

--- a/doc/blue-ocean/turismo-compras-textil.md
+++ b/doc/blue-ocean/turismo-compras-textil.md
@@ -1,0 +1,43 @@
+# Estudo de Caso: Turismo de Compras Têxtil
+
+## Cenários
+
+**Oceano Vermelho:**
+- Foco em preço baixo e alto volume.
+- Concorrência agressiva entre excursões padronizadas.
+- Roteiros exaustivos focados em quantidade de lojas.
+- Logística de transporte precária e desconfortável.
+- Baixa diferenciação, dependência de comissões de atacados genéricos.
+
+**Oceano Azul:**
+- Foco na experiência de compra otimizada, curadoria e consultoria de moda.
+- Público-alvo: Lojistas e revendedores buscando coleções exclusivas e eficiência.
+- Roteiros confortáveis e altamente personalizados.
+- Serviços agregados: logística inteligente de despacho e pré-seleção de fornecedores.
+- Transporte premium e atendimento VIP.
+
+## Matriz ERRC
+
+- **Eliminar:** Visitas a lojas irrelevantes e excursões lotadas.
+- **Reduzir:** Tempo de deslocamento, desgaste físico do comprador, guerra de preços.
+- **Elevar:** Conforto, curadoria de tendências, eficiência operacional do cliente.
+- **Criar:** Consultoria de moda integrada, despacho de mercadoria facilitado, parcerias com confecções de alto padrão.
+
+## Strategy Canvas
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Turismo de Compras Têxtil"
+    x-axis ["Preço do Serviço", "Volume de Lojas", "Desgaste Físico", "Conforto", "Curadoria", "Consultoria", "Logística Expressa"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [6, 9, 8, 3, 2, 1, 3]
+    line [8, 4, 3, 9, 9, 8, 9]
+```
+*(Nota: Linha 1 = Oceano Vermelho; Linha 2 = Oceano Azul)*
+
+## Veja Também
+
+- [Pousadas e Campings](./pousadas-e-campings.md)
+- [Academia de Escalada](./academia-de-escalada.md)
+- [Personal Trainer](./personal-trainer.md)
+- [Consultoria Empreendedora](./consultoria-empreendedora.md)


### PR DESCRIPTION
Creates the requested Blue Ocean portfolio case studies under `doc/blue-ocean/` formatted in Markdown, featuring an objective tone, ERRC grids, Mermaid Strategy Canvas (`xychart-beta`) charts, and cross-linking between documents.

---
*PR created automatically by Jules for task [11940201208698864385](https://jules.google.com/task/11940201208698864385) started by @govinda777*