### PR TITLE
docs: add more blue ocean case studies and update cross-links

### DIFF
--- a/doc/blue-ocean/academia-de-escalada.md
+++ b/doc/blue-ocean/academia-de-escalada.md
@@ -37,6 +37,9 @@ xychart-beta
 
 ## Veja Também
 
+- [Salão de Beleza](./salao-de-beleza.md)
+- [Pet Shop](./pet-shop.md)
+- [Escola de Idiomas](./escola-de-idiomas.md)
 - [Turismo de Compras Têxtil](./turismo-compras-textil.md)
 - [Pousadas e Campings](./pousadas-e-campings.md)
 - [Personal Trainer](./personal-trainer.md)

--- a/doc/blue-ocean/consultoria-empreendedora.md
+++ b/doc/blue-ocean/consultoria-empreendedora.md
@@ -37,6 +37,9 @@ xychart-beta
 
 ## Veja Também
 
+- [Salão de Beleza](./salao-de-beleza.md)
+- [Pet Shop](./pet-shop.md)
+- [Escola de Idiomas](./escola-de-idiomas.md)
 - [Turismo de Compras Têxtil](./turismo-compras-textil.md)
 - [Pousadas e Campings](./pousadas-e-campings.md)
 - [Academia de Escalada](./academia-de-escalada.md)

--- a/doc/blue-ocean/escola-de-idiomas.md
+++ b/doc/blue-ocean/escola-de-idiomas.md
@@ -1,0 +1,46 @@
+# Estudo de Caso: Escola de Idiomas
+
+## Cenários
+
+**Oceano Vermelho:**
+- Aulas focadas apenas em gramática teórica e livros engessados.
+- Contratos de longo prazo (anos) com altas taxas de cancelamento.
+- Competição massiva entre redes de franquias oferecendo "fluência em x anos".
+- Avaliações baseadas apenas em provas escritas.
+- Turmas grandes e heterogêneas sem foco específico.
+
+**Oceano Azul:**
+- Ensino orientado a objetivos práticos imediatos (Inglês para Entrevistas de TI, Espanhol para Viagens de Negócios).
+- Imersão cultural e vivência (aulas em cenários reais, degustação cultural).
+- Assinatura flexível de módulos rápidos e independentes.
+- Gamificação do aprendizado com forte integração de comunidade de conversação diária.
+- Mentoria de carreira atrelada à fluência.
+
+## Matriz ERRC
+
+- **Eliminar:** Contratos engessados de 2 a 5 anos, livros didáticos ultrapassados, testes teóricos irrelevantes.
+- **Reduzir:** Aulas apenas de gramática, promessas genéricas de fluência, turmas muito grandes.
+- **Elevar:** Aplicabilidade imediata do idioma, networking na comunidade de alunos, prática oral diária.
+- **Criar:** Cursos ultra-nichados (por profissão/objetivo), mentorias culturais, plataformas de conexão entre nativos e alunos.
+
+## Strategy Canvas
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Escola de Idiomas"
+    x-axis ["Preço Anual", "Foco em Gramática", "Contratos Longos", "Prática Direcionada", "Flexibilidade", "Cursos Nichados"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [7, 9, 9, 3, 2, 1]
+    line [5, 2, 1, 9, 9, 9]
+```
+*(Nota: Linha 1 = Oceano Vermelho; Linha 2 = Oceano Azul)*
+
+## Veja Também
+
+- [Salão de Beleza](./salao-de-beleza.md)
+- [Pet Shop](./pet-shop.md)
+- [Turismo de Compras Têxtil](./turismo-compras-textil.md)
+- [Pousadas e Campings](./pousadas-e-campings.md)
+- [Academia de Escalada](./academia-de-escalada.md)
+- [Personal Trainer](./personal-trainer.md)
+- [Consultoria Empreendedora](./consultoria-empreendedora.md)

--- a/doc/blue-ocean/personal-trainer.md
+++ b/doc/blue-ocean/personal-trainer.md
@@ -37,6 +37,9 @@ xychart-beta
 
 ## Veja Também
 
+- [Salão de Beleza](./salao-de-beleza.md)
+- [Pet Shop](./pet-shop.md)
+- [Escola de Idiomas](./escola-de-idiomas.md)
 - [Turismo de Compras Têxtil](./turismo-compras-textil.md)
 - [Pousadas e Campings](./pousadas-e-campings.md)
 - [Academia de Escalada](./academia-de-escalada.md)

--- a/doc/blue-ocean/pet-shop.md
+++ b/doc/blue-ocean/pet-shop.md
@@ -1,0 +1,46 @@
+# Estudo de Caso: Pet Shop
+
+## Cenários
+
+**Oceano Vermelho:**
+- Venda focada em rações comuns e acessórios massificados.
+- Competição direta em preço de banho e tosa.
+- Atendimento impessoal no balcão.
+- Margens espremidas por grandes redes de hipermercados pet.
+- Espaço apenas para compra rápida, sem permanência.
+
+**Oceano Azul:**
+- Foco em saúde, bem-estar e alimentação natural para pets.
+- Especialização em raças ou condições específicas (pets idosos, alérgicos).
+- Serviços de "Pet Spa" e tratamentos relaxantes integrados.
+- Criação de uma padaria ou confeitaria pet no local para gerar engajamento.
+- Cursos rápidos para tutores (adestramento básico em casa, nutrição pet).
+
+## Matriz ERRC
+
+- **Eliminar:** Venda de animais, briga por centavos na venda de ração básica.
+- **Reduzir:** Banho e tosa em série industrial, prateleiras apenas com commodities.
+- **Elevar:** Cuidados preventivos, alimentação natural e específica, educação do tutor.
+- **Criar:** Produtos gastronômicos para pets, estética premium (spa), eventos de socialização de raças.
+
+## Strategy Canvas
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Pet Shop"
+    x-axis ["Preço dos Serviços", "Venda de Commodities", "Banho e Tosa em Série", "Alimentação Natural", "Pet Spa", "Educação do Tutor"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [5, 9, 8, 2, 1, 1]
+    line [8, 3, 2, 9, 8, 9]
+```
+*(Nota: Linha 1 = Oceano Vermelho; Linha 2 = Oceano Azul)*
+
+## Veja Também
+
+- [Salão de Beleza](./salao-de-beleza.md)
+- [Escola de Idiomas](./escola-de-idiomas.md)
+- [Turismo de Compras Têxtil](./turismo-compras-textil.md)
+- [Pousadas e Campings](./pousadas-e-campings.md)
+- [Academia de Escalada](./academia-de-escalada.md)
+- [Personal Trainer](./personal-trainer.md)
+- [Consultoria Empreendedora](./consultoria-empreendedora.md)

--- a/doc/blue-ocean/pousadas-e-campings.md
+++ b/doc/blue-ocean/pousadas-e-campings.md
@@ -37,6 +37,9 @@ xychart-beta
 
 ## Veja Também
 
+- [Salão de Beleza](./salao-de-beleza.md)
+- [Pet Shop](./pet-shop.md)
+- [Escola de Idiomas](./escola-de-idiomas.md)
 - [Turismo de Compras Têxtil](./turismo-compras-textil.md)
 - [Academia de Escalada](./academia-de-escalada.md)
 - [Personal Trainer](./personal-trainer.md)

--- a/doc/blue-ocean/salao-de-beleza.md
+++ b/doc/blue-ocean/salao-de-beleza.md
@@ -1,0 +1,46 @@
+# Estudo de Caso: Salão de Beleza
+
+## Cenários
+
+**Oceano Vermelho:**
+- Guerra de preços por cortes e serviços básicos.
+- Atendimento focado apenas na execução rápida do serviço.
+- Longo tempo de espera em ambientes ruidosos e caóticos.
+- Dependência de pacotes de química genérica.
+- Público generalista sem diferenciação de nicho.
+
+**Oceano Azul:**
+- Foco em "Spa Urbano" e saúde do couro cabeludo e fios (tricologia).
+- Consultoria de imagem integrada ao visagismo.
+- Atendimento com hora marcada estrita em ambiente relaxante (aromaterapia, som ambiente).
+- Especialização em nichos (ex: transição capilar, cacheadas, terapia capilar orgânica).
+- Assinaturas recorrentes de manutenção e venda de tratamentos exclusivos.
+
+## Matriz ERRC
+
+- **Eliminar:** Serviços superlotados de baixa margem, leitura de revistas antigas, pacotes genéricos.
+- **Reduzir:** Tempo de espera, ruído excessivo de secadores, competição por preço em serviços básicos.
+- **Elevar:** Saúde dos fios, experiência sensorial, consultoria personalizada de imagem.
+- **Criar:** Terapias holísticas capilares, assinaturas de manutenção mensal, diagnósticos precisos de tricologia.
+
+## Strategy Canvas
+
+```mermaid
+xychart-beta
+    title "Strategy Canvas: Salão de Beleza"
+    x-axis ["Preço Base", "Serviços Genéricos", "Tempo de Espera", "Experiência Sensorial", "Saúde Capilar", "Personalização"]
+    y-axis "Nível de Oferta" 0 --> 10
+    line [4, 9, 8, 2, 3, 2]
+    line [8, 2, 1, 9, 9, 9]
+```
+*(Nota: Linha 1 = Oceano Vermelho; Linha 2 = Oceano Azul)*
+
+## Veja Também
+
+- [Pet Shop](./pet-shop.md)
+- [Escola de Idiomas](./escola-de-idiomas.md)
+- [Turismo de Compras Têxtil](./turismo-compras-textil.md)
+- [Pousadas e Campings](./pousadas-e-campings.md)
+- [Academia de Escalada](./academia-de-escalada.md)
+- [Personal Trainer](./personal-trainer.md)
+- [Consultoria Empreendedora](./consultoria-empreendedora.md)

--- a/doc/blue-ocean/turismo-compras-textil.md
+++ b/doc/blue-ocean/turismo-compras-textil.md
@@ -37,6 +37,9 @@ xychart-beta
 
 ## Veja Também
 
+- [Salão de Beleza](./salao-de-beleza.md)
+- [Pet Shop](./pet-shop.md)
+- [Escola de Idiomas](./escola-de-idiomas.md)
 - [Pousadas e Campings](./pousadas-e-campings.md)
 - [Academia de Escalada](./academia-de-escalada.md)
 - [Personal Trainer](./personal-trainer.md)


### PR DESCRIPTION
Added three new Blue Ocean Strategy case studies (`salao-de-beleza.md`, `pet-shop.md`, `escola-de-idiomas.md`) in `doc/blue-ocean/` containing strategy scenarios, ERRC grid, and Mermaid xychart-beta Strategy Canvas.
Updated the existing 5 case studies to add these new cases in their `Veja Também` cross-link sections to form a complete interconnected portfolio.

---
*PR created automatically by Jules for task [14140840204725856581](https://jules.google.com/task/14140840204725856581) started by @govinda777*